### PR TITLE
Run test_persistentregistry under PyPy/3, and fix it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - TOXENV=py33
     - TOXENV=py34
     - TOXENV=pypy
+    - TOXENV=pypy3
     - TOXENV=coverage
     - TOXENV=docs
 install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 4.2.2 (unreleased)
 ------------------
 
--TBD
+- Fix test cases for PyPy and PyPy3.
 
 
 4.2.1 (2014-03-19)

--- a/src/zope/component/tests/test_persistentregistry.py
+++ b/src/zope/component/tests/test_persistentregistry.py
@@ -37,6 +37,8 @@ class PersistentAdapterRegistryTests(unittest.TestCase):
             def new_ghost(self, oid, obj):
                 obj._p_jar = self._jar
                 obj._p_oid = oid
+            def update_object_size_estimation(self, oid, size):
+                return
 
         return _Cache(jar)
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
 # Jython support pending 2.7 support, due 2012-07-15 or so.  See:
 # http://fwierzbicki.blogspot.com/2012/03/adconion-to-fund-jython-27.html
 #   py26,py27,py32,jython,pypy,coverage,docs
-    py26,py26min,py27,pypy,py32,py33,py34,coverage,docs
+    py26,py26min,py27,pypy,pypy3,py32,py33,py34,coverage,docs
 
 [mindeps]
 deps =
@@ -33,14 +33,6 @@ commands =
 usedevelop = true
 basepython =
     python2.6
-deps =
-    {[mindeps]deps}
-    nose
-commands =
-    nosetests -I persistentregistry -I security
-
-[testenv:pypy]
-usedevelop = true
 deps =
     {[mindeps]deps}
     nose


### PR DESCRIPTION
Prior to this PR, only a subset of the unit tests were being run under PyPy because `persistent` wasn't available. Now that it is, run all the unit tests under PyPy, and fix the one that failed due to an incomplete mock object:

```python
Traceback (most recent call last):
  File "/zope.component/src/zope/component/tests/test_persistentregistry.py", line 110, in test___setstate___rebuilds__v_lookup
    registry._p_changed = None # clears volatile '_v_lookup'
  File "//zope.component/.tox/pypy/site-packages/persistent/persistence.py", line 279, in __setattr__
    _OSA(self, name, value)
  File "//zope.component/.tox/pypy/site-packages/persistent/persistence.py", line 165, in _set_changed
    self._p_deactivate()
  File "//zope.component/.tox/pypy/site-packages/persistent/persistence.py", line 406, in _p_deactivate
    self._p_invalidate_deactivate_helper()
  File "//zope.component/.tox/pypy/site-packages/persistent/persistence.py", line 436, in _p_invalidate_deactivate_helper
    cache.update_object_size_estimation(_OGA(self, '_Persistent__oid'), -1)
AttributeError: '_Cache' object has no attribute 'update_object_size_estimation'
```

This project has the same issue documented in zopefoundation/zope.catalog#2: The doctests are only being run on a single platform. If the doctests are run under PyPy, there are 9 failures, including two `zope.interface` "could not adapt" TypeErrors and some interesting cases where a `zope.security._proxy._Proxy` is expected but a `zope.location.location.LocationProxy` is seen instead. This PR doesn't touch those.