### PR TITLE
Add failing functional/integration tests for the interaction between zope.security/zope.proxy/zope.component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ env:
     - TOXENV=py26
     - TOXENV=py26min
     - TOXENV=py27
+    - TOXENV=py27-pure
     - TOXENV=py32
     - TOXENV=py33
     - TOXENV=py34
+    - TOXENV=py34-pure
     - TOXENV=pypy
     - TOXENV=pypy3
     - TOXENV=coverage

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
 # Jython support pending 2.7 support, due 2012-07-15 or so.  See:
 # http://fwierzbicki.blogspot.com/2012/03/adconion-to-fund-jython-27.html
 #   py26,py27,py32,jython,pypy,coverage,docs
-    py26,py26min,py27,pypy,pypy3,py32,py33,py34,coverage,docs
+    py26,py26min,py27,py27-pure,pypy,pypy3,py32,py34-pure,py33,py34,coverage,docs
 
 [mindeps]
 deps =
@@ -28,6 +28,18 @@ deps =
     {[fulldeps]deps}
 commands =
     python setup.py -q test -q
+
+[testenv:py34-pure]
+basepython =
+    python3.4
+setenv =
+    PURE_PYTHON = 1
+
+[testenv:py27-pure]
+basepython =
+    python3.4
+setenv =
+    PURE_PYTHON = 1
 
 [testenv:py26min]
 usedevelop = true


### PR DESCRIPTION
These previously existed in a zcml.rst doctest only and will fail under PyPy until zopefoundation/zope.security#11 and/or zopefoundation/zope.proxy#8 is fixed.