### PR TITLE
Note explicit support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: false
+python: "3.5"
 env:
     - TOXENV=py26
     - TOXENV=py26-minimal
@@ -10,6 +11,8 @@ env:
     - TOXENV=py33
     - TOXENV=py34
     - TOXENV=py34-pure
+    - TOXENV=py35
+    - TOXENV=py35-pure
     - TOXENV=pypy3
     - TOXENV=coverage
     - TOXENV=docs

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 4.2.3 (unreleased)
 ------------------
 
-- TBD
+- Claim support for Python 3.5.
 
 4.2.2 (2015-06-04)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ setup(
         "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Framework :: Zope3",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
 # Jython support pending 2.7 support, due 2012-07-15 or so.  See:
 # http://fwierzbicki.blogspot.com/2012/03/adconion-to-fund-jython-27.html
 #   py26,py27,py32,jython,pypy,coverage,docs
-    py26,py26-minimal,py27,py27-pure,pypy,py32,py33,py34,py34-pure,pypy3,coverage,docs
+    py26,py26-minimal,py27,py27-pure,pypy,py32,py33,py34,py34-pure,py35,py35-pure,pypy3,coverage,docs
 
 [mindeps]
 deps =
@@ -39,6 +39,12 @@ commands =
 [testenv:py34-pure]
 basepython =
     python3.4
+setenv =
+    PURE_PYTHON = 1
+
+[testenv:py35-pure]
+basepython =
+    python3.5
 setenv =
     PURE_PYTHON = 1
 


### PR DESCRIPTION
The `python: 3.5` part in `.travis.yml` is needed due to a travis issue (https://github.com/travis-ci/travis-ci/issues/4794#issuecomment-143758799)