### PR TITLE
Make Travis look nicer by specifying python version only for py35 TOXENV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: python
 sudo: false
-python: "3.5"
+matrix:
+  include:
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.5
+      env: TOXENV=py35-pure
 env:
     - TOXENV=py26
     - TOXENV=py26-minimal
@@ -11,8 +16,6 @@ env:
     - TOXENV=py33
     - TOXENV=py34
     - TOXENV=py34-pure
-    - TOXENV=py35
-    - TOXENV=py35-pure
     - TOXENV=pypy3
     - TOXENV=coverage
     - TOXENV=docs


### PR DESCRIPTION
As discussed in #17 