### PR TITLE
Fix tox and Travis by using zope.testrunner

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+source = zope.component
+
+[report]
+exclude_lines =
+    pragma: no cover
+    pragma NO COVER
+    if __name__ == '__main__':
+    raise NotImplementedError

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,41 @@ language: python
 sudo: false
 matrix:
   include:
+    - python: 2.7
+      env: PURE_PYTHON=1
+    - python: 2.7
+      env: DOCS=1
+      # The doctests only run on Python 2.7
+    - python: 2.7
+      env: MINIMAL="-t !persistentregistry -t !security"
     - python: 3.5
-      env: TOXENV=py35
-    - python: 3.5
-      env: TOXENV=py35-pure
-env:
-    - TOXENV=py27
-    - TOXENV=py27-minimal
-    - TOXENV=py27-pure
-    - TOXENV=pypy
-    - TOXENV=py33
-    - TOXENV=py34
-    - TOXENV=py34-pure
-    - TOXENV=pypy3
-    - TOXENV=coverage
-    - TOXENV=docs
-install:
-    - pip install tox
+      env: PURE_PYTHON=1
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+  - pypy-5.6.0
+  - pypy3.3-5.5-alpha
+
 script:
-    - tox
+  - coverage run -m zope.testrunner --test-path=src $MINIMAL
+  - if [[ -n "$DOCS" ]]; then sphinx-build -b html    -d docs/_build/doctrees docs docs/_build/html; fi
+  - if [[ -n "$DOCS" ]]; then sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest; fi
+
+after_success:
+  - coveralls
 notifications:
-    email: false
+  email: false
+
+install:
+  - pip install -U pip setuptools
+  - pip install -U coveralls coverage
+  - if [[ -n "$MINIMAL" ]]; then pip install -U -e ".[mintests]"; fi
+  - if [[ -z "$MINIMAL" ]]; then pip install -U -e ".[test,docs]"; fi
+
+
+cache: pip
+
+before_cache:
+  - rm -f $HOME/.cache/pip/log/debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,10 @@ sudo: false
 matrix:
   include:
     - python: 2.7
-      env: PURE_PYTHON=1
-    - python: 2.7
       env: DOCS=1
       # The doctests only run on Python 2.7
     - python: 2.7
       env: MINIMAL="-t !persistentregistry -t !security"
-    - python: 3.5
-      env: PURE_PYTHON=1
 python:
   - 2.7
   - 3.4
@@ -22,7 +18,7 @@ python:
 script:
   - coverage run -m zope.testrunner --test-path=src $MINIMAL
   - if [[ -n "$DOCS" ]]; then sphinx-build -b html    -d docs/_build/doctrees docs docs/_build/html; fi
-  - if [[ -n "$DOCS" ]]; then sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest; fi
+  - if [[ -n "$DOCS" ]]; then coverage run `which sphinx-build` -b doctest -d docs/_build/doctrees docs docs/_build/doctest; fi
 
 after_success:
   - coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,11 @@ Changes
 4.4.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for Python 3.6.
 
+- Drop support for Python 3.3.
+
+- Drop support for "setup.py test".
 
 4.3.0 (2016-08-26)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,6 @@ where=src
 [aliases]
 dev = develop easy_install zope.component[testing]
 docs = easy_install zope.component[docs]
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -22,51 +22,44 @@
 import os
 from setuptools import setup, find_packages
 
+HOOK_REQUIRES = [
+    'zope.hookable',
+]
 
-TESTS_REQUIRE = [
-    'zope.testing',
-    'zope.component[hook]',
-    'zope.component[persistentregistry]',
-    'zope.component[security]',
-    'zope.component[zcml]',
+PERSISTENTREGISTRY_REQUIRES = [
+    'persistent',
+]
+
+SECURITY_REQUIRES = [
+    'zope.location',
+    'zope.proxy',
+    'zope.security',
+]
+
+ZCML_REQUIRES = [
+    'zope.configuration',
+    'zope.i18nmessageid',
+]
+
+MIN_TESTS_REQUIRE = (
+    HOOK_REQUIRES
+    + ZCML_REQUIRES
+    + [
+        'zope.testing',
+        'zope.testrunner',
     ]
+)
 
-def _modname(path, base, name=''):
-    if path == base:
-        return name
-    dirname, basename = os.path.split(path)
-    return _modname(dirname, base, basename + '.' + name)
-
-def alltests():
-    import logging
-    import pkg_resources
-    import unittest
-
-    class NullHandler(logging.Handler):
-        level = 50
-
-        def emit(self, record):
-            pass
-
-    logging.getLogger().addHandler(NullHandler())
-
-    suite = unittest.TestSuite()
-    base = pkg_resources.working_set.find(
-        pkg_resources.Requirement.parse('zope.component')).location
-    for dirpath, dirnames, filenames in os.walk(base):
-        if os.path.basename(dirpath) == 'tests':
-            for filename in filenames:
-                if ( filename.endswith('.py') and
-                     filename.startswith('test') ):
-                    mod = __import__(
-                        _modname(dirpath, base, os.path.splitext(filename)[0]),
-                        {}, {}, ['*'])
-                    suite.addTest(mod.test_suite())
-    return suite
+TESTS_REQUIRE = (
+    MIN_TESTS_REQUIRE
+    + PERSISTENTREGISTRY_REQUIRES
+    + SECURITY_REQUIRES
+)
 
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
+        return f.read()
 
 setup(
     name='zope.component',
@@ -80,9 +73,9 @@ setup(
         read('README.rst')
         + '\n' +
         read('CHANGES.rst')
-        ),
-    packages = find_packages('src'),
-    package_dir = {'': 'src'},
+    ),
+    packages=find_packages('src'),
+    package_dir={'': 'src'},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
@@ -93,35 +86,34 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Framework :: Zope3",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     namespace_packages=['zope',],
-    tests_require = TESTS_REQUIRE,
-    test_suite='__main__.alltests',
-    install_requires=['setuptools',
-                      'zope.interface>=4.1.0',
-                      'zope.event',
-                      ],
-    include_package_data = True,
-    zip_safe = False,
-    extras_require = {
-        'hook': ['zope.hookable'],
-        'persistentregistry': ['persistent'],
-        'security': ['zope.location',
-                    'zope.proxy',
-                    'zope.security',
-                    ],
-        'zcml': ['zope.configuration',
-                'zope.i18nmessageid',
-                ],
+    tests_require=TESTS_REQUIRE,
+    install_requires=[
+        'setuptools',
+        'zope.interface>=4.1.0',
+        'zope.event',
+    ],
+    include_package_data=True,
+    zip_safe=False,
+    extras_require={
+        'hook': HOOK_REQUIRES,
+        'persistentregistry': PERSISTENTREGISTRY_REQUIRES,
+        'security': SECURITY_REQUIRES,
+        'zcml': ZCML_REQUIRES,
+        'mintests': MIN_TESTS_REQUIRE,
         'test': TESTS_REQUIRE,
-        'testing': TESTS_REQUIRE + ['nose', 'coverage'],
-        'docs': ['Sphinx', 'repoze.sphinx.autointerface'],
-        },
-    )
+        'docs': [
+            'Sphinx',
+            'repoze.sphinx.autointerface',
+            'ZODB',
+        ],
+    },
+)

--- a/tox.ini
+++ b/tox.ini
@@ -2,42 +2,29 @@
 envlist =
 # Jython support pending 2.7 support, due 2012-07-15 or so.  See:
 # http://fwierzbicki.blogspot.com/2012/03/adconion-to-fund-jython-27.html
-    py27,py27-minimal,py27-pure,pypy,py33,py34,py34-pure,py35,py35-pure,pypy3,coverage,docs
+    py27,py27-minimal,py27-pure,pypy,py33,py34,py34-pure,py35,py35-pure,py36,pypy3,coverage,docs
 
 [mindeps]
 deps =
-    zope.event
-    zope.hookable
-    zope.i18nmessageid
-    zope.interface
-    zope.schema
-    zope.configuration
+    .[mintests]
 
 [fulldeps]
 deps =
-    {[mindeps]deps}
-    persistent
-    zope.location
-    zope.proxy
-    zope.security
-    zope.testing
+    .[test]
 
 [testenv]
 deps =
     {[fulldeps]deps}
 commands =
-    python setup.py -q test -q
+    zope-testrunner --test-path=src
 
 [testenv:py27-minimal]
-usedevelop = true
 basepython =
     python2.7
 deps =
     {[mindeps]deps}
-    ordereddict
-    nose
 commands =
-    nosetests -I persistentregistry -I security
+    zope-testrunner --test-path=src -t !persistentregistry -t !security
 
 [testenv:py34-pure]
 basepython =
@@ -60,18 +47,6 @@ setenv =
     PURE_PYTHON = 1
     PIP_CACHE_DIR = {envdir}/.cache
 
-[testenv:coverage]
-usedevelop = true
-basepython =
-    python2.7
-commands =
-    nosetests --with-xunit --with-xcoverage
-deps =
-    {[fulldeps]deps}
-    nose
-    coverage
-    nosexcover
-
 [testenv:docs]
 basepython =
     python2.7
@@ -80,8 +55,4 @@ commands =
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
 deps =
     {[fulldeps]deps}
-    ZODB3
-    Sphinx
-    repoze.sphinx.autointerface
-#   Ugh.  Need this for docs/testlayer.rst
-    zope.testrunner
+    .[docs]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
 # Jython support pending 2.7 support, due 2012-07-15 or so.  See:
 # http://fwierzbicki.blogspot.com/2012/03/adconion-to-fund-jython-27.html
-    py27,py27-minimal,py27-pure,pypy,py33,py34,py34-pure,py35,py35-pure,py36,pypy3,coverage,docs
+    py27,py27-minimal,pypy,py34,py35,py36,pypy3,docs
 
 [mindeps]
 deps =


### PR DESCRIPTION
DRY with regards to dependencies. This lets us simplify travis to not use Tox which in turn lets us easily enable coveralls.

Add Python 3.6, drop Python 3.3. Drop support for 'setup.py test.'

Fixes #26

Are the PURE_PYTHON builds actually necessary? We are testing PyPy which is pure-python automatically.