### PR TITLE
100% coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,8 @@
 [run]
 source = zope.component
+omit =
+    src/zope/component/standalonetests.py
+    # Runs in a subprocess
 
 [report]
 exclude_lines =
@@ -7,3 +10,4 @@ exclude_lines =
     pragma NO COVER
     if __name__ == '__main__':
     raise NotImplementedError
+    self.fail

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage.xml
 .coverage
 dist/
 .eggs/
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 matrix:
   include:
     - python: 2.7
-      env: MINIMAL="-t !persistentregistry -t !security"
+      env: MINIMAL=1
 python:
   - 2.7
   - 3.4
@@ -12,7 +12,7 @@ python:
   - pypy-5.6.0
 
 script:
-  - coverage run -m zope.testrunner --test-path=src $MINIMAL
+  - coverage run -m zope.testrunner --test-path=src
   - if [[ -z "$MINIMAL" ]]; then sphinx-build                      -b html    -d docs/_build/doctrees docs docs/_build/html; fi
   - if [[ -z "$MINIMAL" ]]; then coverage run -a `which sphinx-build` -b doctest -d docs/_build/doctrees docs docs/_build/doctest; fi
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,13 @@ Changes
 
 - Drop support for "setup.py test".
 
+- Code coverage reports are now `produced and hosted by coveralls.io
+  <https://coveralls.io/github/zopefoundation/zope.component>`_, and
+  PRs must keep them at 100%.
+
+- Internal test code in ``zope.component.testfiles`` has been adjusted
+  and in some cases removed.
+
 4.3.0 (2016-08-26)
 ------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,3 +14,6 @@ include *.py
 include .travis.yml
 include buildout.cfg
 include tox.ini
+include .coveragerc
+
+prune docs/_build

--- a/README.rst
+++ b/README.rst
@@ -7,10 +7,16 @@
 
 .. image:: https://travis-ci.org/zopefoundation/zope.component.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.component
+        :alt: Build Status
 
 .. image:: https://readthedocs.org/projects/zopecomponent/badge/?version=latest
         :target: http://zopecomponent.readthedocs.org/en/latest/
         :alt: Documentation Status
+
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.component/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.component?branch=master
+        :alt: Coverage Status
+
 
 .. note::
 

--- a/docs/testlayer.rst
+++ b/docs/testlayer.rst
@@ -76,6 +76,11 @@ ZCMLLayer
 
 We now want a layer that loads up some ZCML from a file. The default
 is ``ftesting.zcml``, but here we'll load a test ``testlayer.zcml``.
+We can also choose to provide extra ZCML features that are used `to
+conditionally control processing of certain directives
+<http://zopeconfiguration.readthedocs.io/en/latest/narr.html#making-specific-directives-conditional>`_
+(here we use "devmode", a common condition for controlling development
+options like debugging output).
 
 .. doctest::
 
@@ -83,17 +88,21 @@ is ``ftesting.zcml``, but here we'll load a test ``testlayer.zcml``.
    >>> import zope.component.testfiles
    >>> zcml_file_layer = ZCMLFileLayer(
    ...     zope.component.testfiles,
-   ...     'testlayer.zcml')
+   ...     'testlayer.zcml',
+   ...     features=["devmode"])
 
    >>> class TestCase(unittest.TestCase):
    ...    layer = zcml_file_layer
    ...
    ...    def testFoo(self):
+   ...        # The feature was registered
+   ...        self.assertTrue(self.layer.context.hasFeature('devmode'))
    ...        # we should now have the adapter registered
    ...        from zope import component
    ...        from zope.component.testfiles import components
-   ...        self.assert_(isinstance(
-   ...            components.IApp2(components.content), components.Comp2))
+   ...        self.assertIsInstance(
+   ...            components.IApp2(components.content), components.Comp2)
+
 
 Since the ZCML sets up an adapter, we expect the tests to pass:
 

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         + '\n' +
         read('CHANGES.rst')
     ),
+    keywords="interface component coupling loose utility adapter",
     packages=find_packages('src'),
     package_dir={'': 'src'},
     classifiers=[

--- a/src/zope/component/standalonetests.py
+++ b/src/zope/component/standalonetests.py
@@ -1,13 +1,14 @@
 """
 See: https://bugs.launchpad.net/zope3/+bug/98401
 """
+
 import sys
 import pickle
 
-def write(x): # pragma: NO COVER
+def write(x):
     sys.stdout.write('%s\n' % x)
 
-if __name__ == "__main__": #pragma NO COVER (runs in subprocess)
+if __name__ == "__main__":
     if sys.version_info[0] >= 3:
         # TextIO? Are you kidding me?
         data = sys.stdin.buffer.read()

--- a/src/zope/component/testfiles/components.py
+++ b/src/zope/component/testfiles/components.py
@@ -53,10 +53,6 @@ class Comp2(object):
     def __init__(self, context):
         self.context = context
 
-class Comp3(object):
-    def __init__(self, context):
-        self.context = context
-
 @adapter(IContent)
 @implementer(IApp)
 @named('app')

--- a/src/zope/component/testfiles/views.py
+++ b/src/zope/component/testfiles/views.py
@@ -15,52 +15,6 @@
 """
 
 from zope.interface import Interface
-from zope.interface import implementer
-from zope.interface import directlyProvides
 
-class Request(object):
-
-    def __init__(self, type):
-        directlyProvides(self, type)
-
-class IR(Interface):
-    pass
-
-class IV(Interface):
-    def index():
-        pass
-
-class IC(Interface): pass
-
-@implementer(IV)
-class V1(object):
-
-    def __init__(self, context, request):
-        self.context = context
-        self.request = request
-
-    def index(self):
-        return 'V1 here'
-
-    def action(self):
-        return 'done'
-
-class VZMI(V1):
-    def index(self):
-        return 'ZMI here'
-
-@implementer(IV)
-class R1(object):
-
-    def index(self):
-        return 'R1 here'
-
-    def action(self):
-        return 'R done'
-
-    def __init__(self, request):
-        pass
-
-
-class RZMI(R1):
+class IC(Interface):
     pass

--- a/src/zope/component/testing.py
+++ b/src/zope/component/testing.py
@@ -18,17 +18,17 @@
 import zope.component.event
 
 # we really don't need special setup now:
+class _PlacelessSetupFallback(object):
+    def cleanUp(self):
+        from zope.component.globalregistry import base
+        base.__init__('base')
+
+    setUp = tearDown = cleanUp
+
 try:
     from zope.testing.cleanup import CleanUp as PlacelessSetup
-except ImportError:
-    class PlacelessSetup(object):
-        def cleanUp(self):
-            from zope.component.globalregistry import base
-            base.__init__('base')
-        def setUp(self):
-            self.cleanUp()
-        def tearDown(self):
-            self.cleanUp()
+except ImportError: # pragma: no cover
+    PlacelessSetup = _PlacelessSetupFallback
 
 def setUp(test=None):
     PlacelessSetup().setUp()

--- a/src/zope/component/testlayer.py
+++ b/src/zope/component/testlayer.py
@@ -17,7 +17,7 @@ import os
 from zope.configuration import xmlconfig, config
 try:
     from zope.testing.cleanup import cleanUp
-except ImportError:
+except ImportError: # pragma: no cover
     def cleanUp():
         pass
 
@@ -62,7 +62,7 @@ class LayerBase(object):
         self.__name__ = name
         self.__module__ = package.__name__
         self.package = package
-        
+
     def setUp(self):
         pass
 

--- a/src/zope/component/tests/__init__.py
+++ b/src/zope/component/tests/__init__.py
@@ -1,1 +1,23 @@
-# tests package
+import unittest
+
+def skipIfNoSecurity(testfunc):
+    try:
+        import zope.security
+    except ImportError:
+        return unittest.skip("zope.security not installed")(testfunc)
+    return testfunc
+
+def fails_if_called(test, msg="This function must not be called.",
+                    arguments=True):
+    """
+    Return a new function (accepting any arguments)
+    that will call test.fail(msg) if it is called.
+
+    :keyword bool arguments: If set to ``False``, then we will
+        not accept any arguments. This can avoid
+        masking when we would expect a TypeError to be raised by
+        calling an instance method against a class.
+    """
+    if not arguments:
+        return lambda: test.fail(msg)
+    return lambda *_args, **__kwargs: test.fail(msg)

--- a/src/zope/component/tests/examples.py
+++ b/src/zope/component/tests/examples.py
@@ -53,9 +53,6 @@ class ISI(Interface):
 class ISII(Interface):
     pass
 
-def noop(*args):
-    pass
-
 class U(object):
 
     def __init__(self, name):
@@ -120,11 +117,6 @@ class Comp(object):
         self.context = context
 
 comp = Comp(1)
-
-@implementer(I3)
-class Comp2(object):
-    def __init__(self, context):
-        self.context = context
 
 
 class ConformsToIComponentLookup(object):

--- a/src/zope/component/tests/test_hookable.py
+++ b/src/zope/component/tests/test_hookable.py
@@ -15,6 +15,7 @@
 """
 import unittest
 
+from zope.component.tests import fails_if_called
 
 class HookableTests(unittest.TestCase):
 
@@ -24,30 +25,25 @@ class HookableTests(unittest.TestCase):
 
     def test_ctor_simple(self):
         from zope.component.hookable import hookable
-        def foo():
-            pass
+        foo = fails_if_called(self)
         hooked = hookable(foo)
         self.assertTrue(hooked.original is foo)
         self.assertTrue(hooked.implementation is foo)
 
     def test_ctor_extra_arg(self):
         from zope.component.hookable import hookable
-        def foo():
-            pass
+        foo = fails_if_called(self)
         self.assertRaises(TypeError, hookable, foo, foo)
 
     def test_ctor_extra_arg_miss(self):
         from zope.component.hookable import hookable
-        def foo():
-            pass
+        foo = fails_if_called(self)
         self.assertRaises(TypeError, hookable, foo, nonesuch=foo)
 
     def test_sethook(self):
         from zope.component.hookable import hookable
-        def foo():
-            pass
-        def bar():
-            pass
+        foo = fails_if_called(self)
+        bar = fails_if_called(self)
         hooked = hookable(foo)
         hooked.sethook(bar)
         self.assertTrue(hooked.original is foo)
@@ -55,10 +51,8 @@ class HookableTests(unittest.TestCase):
 
     def test_reset(self):
         from zope.component.hookable import hookable
-        def foo():
-            pass
-        def bar():
-            pass
+        foo = fails_if_called(self)
+        bar = fails_if_called(self)
         hooked = hookable(foo)
         hooked.sethook(bar)
         hooked.reset()
@@ -67,63 +61,33 @@ class HookableTests(unittest.TestCase):
 
     def test_cant_assign_original(self):
         from zope.component.hookable import hookable
-        def foo():
-            pass
-        def bar():
-            pass
+        foo = fails_if_called(self)
+        bar = fails_if_called(self)
         hooked = hookable(foo)
-        try:
+        with self.assertRaises((TypeError, AttributeError)):
             hooked.original = bar
-        except TypeError:
-            pass
-        except AttributeError:
-            pass
-        else:
-            self.fail('Assigned original')
 
     def test_cant_delete_original(self):
         from zope.component.hookable import hookable
-        def foo():
-            pass
+        foo = fails_if_called(self)
         hooked = hookable(foo)
-        try:
+        with self.assertRaises((TypeError, AttributeError)):
             del hooked.original
-        except TypeError:
-            pass
-        except AttributeError:
-            pass
-        else:
-            self.fail('Deleted original')
 
     def test_cant_assign_implementation(self):
         from zope.component.hookable import hookable
-        def foo():
-            pass
-        def bar():
-            pass
+        foo = fails_if_called(self)
+        bar = fails_if_called(self)
         hooked = hookable(foo)
-        try:
+        with self.assertRaises((TypeError, AttributeError)):
             hooked.implementation = bar
-        except TypeError:
-            pass
-        except AttributeError:
-            pass
-        else:
-            self.fail('Assigned implementation')
 
     def test_cant_delete_implementation(self):
         from zope.component.hookable import hookable
-        def foo():
-            pass
+        foo = fails_if_called(self)
         hooked = hookable(foo)
-        try:
+        with self.assertRaises((TypeError, AttributeError)):
             del hooked.implementation
-        except TypeError:
-            pass
-        except AttributeError:
-            pass
-        else:
-            self.fail('Deleted implementation')
 
     def test_ctor___call__(self):
         from zope.component.hookable import hookable
@@ -133,9 +97,3 @@ class HookableTests(unittest.TestCase):
         hooked = hookable(foo)
         hooked('one', 'two', bar='baz')
         self.assertEqual(_called, [(('one', 'two'), {'bar': 'baz'})])
-
-
-def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(HookableTests),
-    ))

--- a/src/zope/component/tests/test_persistentregistry.py
+++ b/src/zope/component/tests/test_persistentregistry.py
@@ -16,6 +16,14 @@
 import unittest
 
 
+def skipIfNoPersistent(testfunc):
+    try:
+        import persistent
+    except ImportError:
+        return unittest.skip("persistent not installed")(testfunc)
+    return testfunc
+
+@skipIfNoPersistent
 class PersistentAdapterRegistryTests(unittest.TestCase):
 
     def _getTargetClass(self):
@@ -123,7 +131,7 @@ class PersistentAdapterRegistryTests(unittest.TestCase):
         self.assertEqual(registry.__bases__, bases)
         self.assertEqual(registry.ro, [registry] + list(bases))
 
-
+@skipIfNoPersistent
 class PersistentComponentsTests(unittest.TestCase):
 
     def _getTargetClass(self):
@@ -156,9 +164,3 @@ def _makeOctets(s):
     if sys.version_info < (3,):
         return bytes(s)
     return bytes(s, 'ascii') #pragma NO COVERAGE
-
-def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(PersistentAdapterRegistryTests),
-        unittest.makeSuite(PersistentComponentsTests),
-    ))

--- a/src/zope/component/tests/test_registry.py
+++ b/src/zope/component/tests/test_registry.py
@@ -15,6 +15,7 @@
 """
 import unittest
 
+from zope.component.tests import fails_if_called
 
 class Test_dispatchUtilityRegistrationEvent(unittest.TestCase):
 
@@ -48,8 +49,7 @@ class Test_dispatchAdapterRegistrationEvent(unittest.TestCase):
     def test_it(self):
         from zope.component import registry
         class _Registration(object):
-            def factory(self, *args, **kw):
-                pass
+            factory = fails_if_called(self)
         _registration = _Registration()
         _EVENT = object()
         _handled = []
@@ -72,8 +72,7 @@ class Test_dispatchSubscriptionAdapterRegistrationEvent(unittest.TestCase):
     def test_it(self):
         from zope.component import registry
         class _Registration(object):
-            def factory(self, *args, **kw):
-                pass
+            factory = fails_if_called(self)
         _registration = _Registration()
         _EVENT = object()
         _handled = []
@@ -95,8 +94,7 @@ class Test_dispatchHandlerRegistrationEvent(unittest.TestCase):
     def test_it(self):
         from zope.component import registry
         class _Registration(object):
-            def handler(self, *args, **kw):
-                pass
+            handler = fails_if_called(self)
         _registration = _Registration()
         _EVENT = object()
         _handled = []
@@ -121,11 +119,3 @@ class _Monkey(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         for key, value in self.to_restore.items():
             setattr(self.module, key, value)
-
-def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(Test_dispatchUtilityRegistrationEvent),
-        unittest.makeSuite(Test_dispatchAdapterRegistrationEvent),
-        unittest.makeSuite(Test_dispatchSubscriptionAdapterRegistrationEvent),
-        unittest.makeSuite(Test_dispatchHandlerRegistrationEvent),
-    ))

--- a/src/zope/component/tests/test_standalone.py
+++ b/src/zope/component/tests/test_standalone.py
@@ -15,50 +15,41 @@
 """
 import unittest
 
-try:
-    import zope.security
-except ImportError:
-    _HAS_ZOPE_SECURITY = False
-else:
-    _HAS_ZOPE_SECURITY = True
+from zope.component.tests import skipIfNoSecurity
 
-    class StandaloneTests(unittest.TestCase):
-        def testStandalone(self):
-            # See: https://bugs.launchpad.net/zope3/+bug/98401
-            import subprocess
-            import sys
-            import os
-            import pickle
+@skipIfNoSecurity
+class StandaloneTests(unittest.TestCase):
+    def testStandalone(self):
+        # See: https://bugs.launchpad.net/zope3/+bug/98401
+        import subprocess
+        import sys
+        import os
+        import pickle
 
-            executable = os.path.abspath(sys.executable)
-            where = os.path.dirname(os.path.dirname(__file__))
-            program = os.path.join(where, 'standalonetests.py')
-            process = subprocess.Popen([executable, program],
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.STDOUT,
-                                    stdin=subprocess.PIPE)
+        executable = os.path.abspath(sys.executable)
+        where = os.path.dirname(os.path.dirname(__file__))
+        program = os.path.join(where, 'standalonetests.py')
+        process = subprocess.Popen([executable, program],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                                stdin=subprocess.PIPE)
+        try:
+            pickle.dump(sys.path, process.stdin)
+            process.stdin.close()
+
             try:
-                pickle.dump(sys.path, process.stdin)
-                process.stdin.close()
-
-                try:
-                    rc = process.wait()
-                except OSError as e:
-                    # MacIntel raises apparently unimportant EINTR?
-                    if e.errno != 4:
-                        raise # TODO verify sanity of a pass on EINTR :-/
-                if rc != 0:
-                    output = process.stdout.read()
-                    if isinstance(output, bytes):
-                        output = output.decode()
-                    sys.stderr.write('#' * 80 + '\n')
-                    sys.stdout.write(output)
-                    sys.stderr.write('#' * 80 + '\n')
-                    self.fail('Output code: %d' % rc)
-            finally:
-                process.stdout.close()
-
-def test_suite():
-    if _HAS_ZOPE_SECURITY:
-        return unittest.makeSuite(StandaloneTests)
-    return unittest.TestSuite()
+                rc = process.wait()
+            except OSError as e: # pragma: no cover
+                # MacIntel raises apparently unimportant EINTR?
+                if e.errno != 4:
+                    raise # TODO verify sanity of a pass on EINTR :-/
+            if rc != 0: # pragma: no cover
+                output = process.stdout.read()
+                if isinstance(output, bytes):
+                    output = output.decode()
+                sys.stderr.write('#' * 80 + '\n')
+                sys.stdout.write(output)
+                sys.stderr.write('#' * 80 + '\n')
+                self.fail('Output code: %d' % rc)
+        finally:
+            process.stdout.close()

--- a/src/zope/component/tests/test_zcml.py
+++ b/src/zope/component/tests/test_zcml.py
@@ -15,13 +15,8 @@
 """
 import unittest
 
-
-def skipIfNoSecurity(testfunc):
-    try:
-        import zope.security
-    except ImportError:
-        return lambda self: None
-    return testfunc
+from zope.component.tests import fails_if_called
+from zope.component.tests import skipIfNoSecurity
 
 class Test_handler(unittest.TestCase):
 
@@ -112,8 +107,7 @@ class Test_adapter(unittest.TestCase):
     def test_no_for__factory_not_adapts(self):
         #@adapter(IFoo)
         class _Factory(object):
-            def __init__(self, context):
-                self.context = context
+            __init__ = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self.assertRaises(TypeError, self._callFUT, _cfg_ctx, [_Factory])
 
@@ -129,8 +123,7 @@ class Test_adapter(unittest.TestCase):
         @implementer(IBar)
         @named('bar')
         class _Factory(object):
-            def __init__(self, context):
-                self.context = context
+            __init__ = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self._callFUT(_cfg_ctx, [_Factory])
         # Register the adapter
@@ -142,8 +135,7 @@ class Test_adapter(unittest.TestCase):
         from zope.component._declaration import adapter
         @adapter(Interface)
         class _Factory(object):
-            def __init__(self, context):
-                self.context = context
+            __init__ = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self.assertRaises(TypeError, self._callFUT, _cfg_ctx, [_Factory])
 
@@ -282,8 +274,7 @@ class Test_adapter(unittest.TestCase):
         @adapter(Interface)
         @implementer(IFoo)
         class _Factory(object):
-            def __init__(self, context):
-                self.context = context
+            __init__ = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self._callFUT(_cfg_ctx, [_Factory])
         self.assertEqual(len(_cfg_ctx._actions), 3)
@@ -385,8 +376,7 @@ class Test_subscriber(unittest.TestCase):
         from zope.interface import Interface
         class IFoo(Interface):
             pass
-        def _handler(*args):
-            pass
+        _handler = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self.assertRaises(TypeError,
                           self._callFUT, _cfg_ctx, (Interface,),
@@ -396,8 +386,7 @@ class Test_subscriber(unittest.TestCase):
         from zope.interface import Interface
         class Foo(object):
             pass
-        def _handler(*args):
-            pass
+        _handler = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self.assertRaises(TypeError,
                           self._callFUT, _cfg_ctx, (Interface,), Foo,
@@ -426,8 +415,7 @@ class Test_subscriber(unittest.TestCase):
         from zope.interface import Interface
         from zope.component.interface import provideInterface
         from zope.component.zcml import handler
-        def _handler(*args):
-            pass
+        _handler = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self._callFUT(_cfg_ctx, (Interface,), handler=_handler)
         self.assertEqual(len(_cfg_ctx._actions), 2)
@@ -456,8 +444,7 @@ class Test_subscriber(unittest.TestCase):
             pass
         class Foo(object):
             pass
-        def _handler(*args):
-            pass
+        _handler = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self._callFUT(_cfg_ctx, (Interface,), Foo, provides=IFoo)
         self.assertEqual(len(_cfg_ctx._actions), 3)
@@ -786,10 +773,9 @@ class Test_utility(unittest.TestCase):
         from zope.component.zcml import handler
         class IFoo(Interface):
             def bar(self):
-                pass
+                "bar"
         class Foo(object):
-            def bar(self):
-                pass
+            bar = fails_if_called(self)
         _COMPONENT = Foo()
         _cfg_ctx = _makeConfigContext()
         self._callFUT(_cfg_ctx, component=_COMPONENT,
@@ -866,16 +852,13 @@ class Test_view(unittest.TestCase):
             pass
         class IView(Interface):
             def foo():
-                pass
+                "foo"
             def bar():
-                pass
+                "bar"
         class _View(object):
-            def __init__(self, context):
-                self.context = context
-            def foo():
-                pass
-            def bar():
-                pass
+            __init__ = fails_if_called(self)
+            foo = fails_if_called(self)
+            bar = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self.assertRaises(ComponentConfigurationError,
                           self._callFUT, _cfg_ctx, (_View,), IViewType, '',
@@ -888,12 +871,9 @@ class Test_view(unittest.TestCase):
         class IViewType(Interface):
             pass
         class _View(object):
-            def __init__(self, context):
-                self.context = context
-            def foo():
-                pass
-            def bar():
-                pass
+            __init__ = fails_if_called(self)
+            foo = fails_if_called(self)
+            bar = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self.assertRaises(ComponentConfigurationError,
                           self._callFUT, _cfg_ctx, (_View,), IViewType, '',
@@ -930,8 +910,7 @@ class Test_view(unittest.TestCase):
         class IViewType(Interface):
             pass
         class _View(object):
-            def __init__(self, context):
-                self.context = context
+            __init__ = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self.assertRaises(ComponentConfigurationError,
                           self._callFUT, _cfg_ctx, (_View,), IViewType, '',
@@ -944,8 +923,7 @@ class Test_view(unittest.TestCase):
         class IViewType(Interface):
             pass
         class _View(object):
-            def __init__(self, context):
-                self.context = context
+            __init__ = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self._callFUT(_cfg_ctx, (_View,), IViewType, 'test', for_=(Interface,))
         self.assertEqual(len(_cfg_ctx._actions), 4)
@@ -1054,11 +1032,8 @@ class Test_view(unittest.TestCase):
         class IViewType(Interface):
             pass
         class _View(object):
-            def __init__(self, context, request):
-                self.context = context
-                self.request = request
-            def bar(self):
-                pass
+            __init__ = fails_if_called(self)
+            bar = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self._callFUT(_cfg_ctx, [_View], IViewType, '', for_=(Interface,),
                       permission='testing', allowed_attributes=('bar',))
@@ -1079,13 +1054,10 @@ class Test_view(unittest.TestCase):
         from zope.component.zcml import handler
         class IViewType(Interface):
             def bar(self):
-                pass
+                "bar"
         class _View(object):
-            def __init__(self, context, request):
-                self.context = context
-                self.request = request
-            def bar(self):
-                pass
+            __init__ = fails_if_called(self)
+            bar = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self._callFUT(_cfg_ctx, [_View], IViewType, '', for_=(Interface,),
                       permission='testing', allowed_interface=(IViewType,))
@@ -1114,16 +1086,13 @@ class Test_resource(unittest.TestCase):
             pass
         class IView(Interface):
             def foo():
-                pass
+                "foo"
             def bar():
-                pass
+                "bar"
         class _Resource(object):
-            def __init__(self, context):
-                self.context = context
-            def foo():
-                pass
-            def bar():
-                pass
+            __init__ = fails_if_called(self)
+            foo = fails_if_called(self)
+            bar = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self.assertRaises(ComponentConfigurationError,
                           self._callFUT,
@@ -1136,12 +1105,9 @@ class Test_resource(unittest.TestCase):
         class IResourceType(Interface):
             pass
         class _Resource(object):
-            def __init__(self, context):
-                self.context = context
-            def foo():
-                pass
-            def bar():
-                pass
+            __init__ = fails_if_called(self)
+            foo = fails_if_called(self)
+            bar = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self.assertRaises(ComponentConfigurationError,
                           self._callFUT,
@@ -1155,12 +1121,9 @@ class Test_resource(unittest.TestCase):
         class IResourceType(Interface):
             pass
         class _Resource(object):
-            def __init__(self, context):
-                self.context = context
-            def foo():
-                pass
-            def bar():
-                pass
+            __init__ = fails_if_called(self)
+            foo = fails_if_called(self)
+            bar = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self._callFUT(_cfg_ctx, _Resource, IResourceType, 'test')
         self.assertEqual(len(_cfg_ctx._actions), 3)
@@ -1198,10 +1161,8 @@ class Test_resource(unittest.TestCase):
         class _Resource(object):
             def __init__(self, context):
                 self.context = context
-            def foo():
-                pass
-            def bar():
-                pass
+            foo = fails_if_called(self)
+            bar = fails_if_called(self)
         _cfg_ctx = _makeConfigContext()
         self._callFUT(_cfg_ctx, _Resource, IResourceType, 'test',
                       permission='testing', allowed_attributes=('foo',))
@@ -1234,16 +1195,3 @@ def _makeConfigContext():
         def action(self, *args, **kw):
             self._actions.append((args, kw))
     return _Context()
-
-def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(Test_handler),
-        unittest.makeSuite(Test__rolledUpFactory),
-        unittest.makeSuite(Test_adapter),
-        unittest.makeSuite(Test_subscriber),
-        unittest.makeSuite(Test_utility),
-        unittest.makeSuite(Test_interface),
-        unittest.makeSuite(Test_view),
-        unittest.makeSuite(Test_resource),
-        unittest.makeSuite(Test_zcml_functional),
-    ))

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ basepython =
 deps =
     {[mindeps]deps}
 commands =
-    zope-testrunner --test-path=src -t !persistentregistry -t !security
+    zope-testrunner --test-path=src
 
 [testenv:py34-pure]
 basepython =


### PR DESCRIPTION
Fixes #29.

Also simplify the "minimal" environment command by simply skipping tests that can't be run.