### PR TITLE
Produce deprecation warnings for deprecated names, remove unused imports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,8 @@ Changes
 - Always install ``zope.hookable`` as a dependency (the ``hook``
   extra is now empty). ``zope.hookable`` respects the PURE_PYTHON
   environment variable, and has an optional C extension.
-
+- Make accessing names that have been moved to ``zope.interface``
+  produce a ``DeprecationWarning``.
 
 4.4.1 (2017-09-26)
 ------------------

--- a/docs/api/sitemanager.rst
+++ b/docs/api/sitemanager.rst
@@ -7,7 +7,7 @@ Site Manager APIs
 
    .. doctest::
 
-      >>> from zope.component.interfaces import IComponentLookup
+      >>> from zope.interface.interfaces import IComponentLookup
       >>> from zope.component.globalregistry import base
       >>> from zope.component import getGlobalSiteManager
       >>> gsm = getGlobalSiteManager()
@@ -37,7 +37,7 @@ Site Manager APIs
    .. doctest::
 
      >>> from zope.component import getSiteManager
-     >>> from zope.component.interfaces import IComponentLookup
+     >>> from zope.interface.interfaces import IComponentLookup
      >>> IComponentLookup.providedBy(getSiteManager())
      True
 
@@ -85,4 +85,3 @@ Site Manager APIs
      ...
      ComponentLookupError: ('Could not adapt', <instance Ob>,
      <InterfaceClass zope...interfaces.IComponentLookup>)
-

--- a/docs/api/utility.rst
+++ b/docs/api/utility.rst
@@ -200,7 +200,7 @@ Now we create two utilities and insert them in our folder hierarchy:
 
 .. doctest::
 
-   >>> from zope.component.interfaces import IComponentLookup
+   >>> from zope.interface.interfaces import IComponentLookup
    >>> util1 = MyUtility('one', sm1)
    >>> sm1.registerUtility(util1, IMyUtility, 'myutil')
    >>> IComponentLookup(util1) is sm1

--- a/docs/event.rst
+++ b/docs/event.rst
@@ -85,11 +85,11 @@ Then create an event class:
 
 .. doctest::
 
-   >>> class IObjectThrownEvent(zope.component.interfaces.IObjectEvent):
+   >>> class IObjectThrownEvent(zope.interface.interfaces.IObjectEvent):
    ...     """An object has been thrown away"""
 
    >>> @zope.interface.implementer(IObjectThrownEvent)
-   ... class ObjectThrownEvent(zope.component.interfaces.ObjectEvent):
+   ... class ObjectThrownEvent(zope.interface.interfaces.ObjectEvent):
    ...     """An object has been thrown away"""
 
 Create an object and an event:

--- a/docs/socketexample.rst
+++ b/docs/socketexample.rst
@@ -673,10 +673,10 @@ always get the global site manager using the API:
    >>> from zope.component import globalSiteManager
    >>> gsm is globalSiteManager
    True
-   >>> from zope.component.interfaces import IComponentLookup
+   >>> from zope.interface.interfaces import IComponentLookup
    >>> IComponentLookup.providedBy(gsm)
    True
-   >>> from zope.component.interfaces import IComponents
+   >>> from zope.interface.interfaces import IComponents
    >>> IComponents.providedBy(gsm)
    True
 

--- a/setup.py
+++ b/setup.py
@@ -98,9 +98,11 @@ setup(
     tests_require=TESTS_REQUIRE,
     install_requires=[
         'setuptools',
-        'zope.interface >= 4.1.0',
+        'zope.deferredimport >= 4.2.1',
+        'zope.deprecation >= 4.3.0',
         'zope.event',
         'zope.hookable >= 4.2.0',
+        'zope.interface >= 4.1.0',
     ],
     include_package_data=True,
     zip_safe=False,

--- a/src/zope/component/__init__.py
+++ b/src/zope/component/__init__.py
@@ -19,9 +19,9 @@ from zope.interface import moduleProvides
 from zope.interface import named
 from zope.interface import providedBy
 
-from zope.component.interfaces import ComponentLookupError
+from zope.interface.interfaces import ComponentLookupError
 from zope.component.interfaces import IComponentArchitecture
-from zope.component.interfaces import IComponentLookup
+from zope.interface.interfaces import IComponentLookup
 from zope.component.interfaces import IComponentRegistrationConvenience
 from zope.component.interfaces import IFactory
 

--- a/src/zope/component/_api.py
+++ b/src/zope/component/_api.py
@@ -14,22 +14,14 @@
 """Zope 3 Component Architecture
 """
 import sys
-import types
 
 from zope.hookable import hookable
 from zope.interface import Interface
-from zope.interface import implementedBy
-from zope.interface import providedBy
 
-from zope.component.interfaces import IComponentArchitecture
-from zope.component.interfaces import IComponentRegistrationConvenience
 from zope.component.interfaces import IFactory
 from zope.component.interfaces import ComponentLookupError
 from zope.component.interfaces import IComponentLookup
 from zope.component._compat import _BLANK
-from zope.component._declaration import adaptedBy
-from zope.component._declaration import adapter
-from zope.component._declaration import adapts
 
 
 
@@ -204,8 +196,8 @@ def getNextUtility(context, interface, name=''):
     util = queryNextUtility(context, interface, name, _marker)
     if util is _marker:
         raise zope.component.interfaces.ComponentLookupError(
-              "No more utilities for %s, '%s' have been found." % (
-                  interface, name))
+            "No more utilities for %s, '%s' have been found." % (
+                interface, name))
     return util
 
 

--- a/src/zope/component/_api.py
+++ b/src/zope/component/_api.py
@@ -17,12 +17,10 @@ import sys
 
 from zope.hookable import hookable
 from zope.interface import Interface
-
-from zope.component.interfaces import IFactory
 from zope.interface.interfaces import ComponentLookupError
 from zope.interface.interfaces import IComponentLookup
 
-
+from zope.component.interfaces import IFactory
 
 # getSiteManager() returns a component registry.  Although the term
 # "site manager" is deprecated in favor of "component registry",

--- a/src/zope/component/_api.py
+++ b/src/zope/component/_api.py
@@ -19,9 +19,8 @@ from zope.hookable import hookable
 from zope.interface import Interface
 
 from zope.component.interfaces import IFactory
-from zope.component.interfaces import ComponentLookupError
-from zope.component.interfaces import IComponentLookup
-from zope.component._compat import _BLANK
+from zope.interface.interfaces import ComponentLookupError
+from zope.interface.interfaces import IComponentLookup
 
 
 
@@ -81,26 +80,26 @@ def queryAdapterInContext(object, interface, context, default=None):
 
     return getSiteManager(context).queryAdapter(object, interface, '', default)
 
-def getAdapter(object, interface=Interface, name=_BLANK, context=None):
+def getAdapter(object, interface=Interface, name=u'', context=None):
     adapter = queryAdapter(object, interface, name, None, context)
     if adapter is None:
         raise ComponentLookupError(object, interface, name)
     return adapter
 
-def queryAdapter(object, interface=Interface, name=_BLANK, default=None,
+def queryAdapter(object, interface=Interface, name=u'', default=None,
                  context=None):
     if context is None:
         return adapter_hook(interface, object, name, default)
     return getSiteManager(context).queryAdapter(object, interface, name,
                                                 default)
 
-def getMultiAdapter(objects, interface=Interface, name=_BLANK, context=None):
+def getMultiAdapter(objects, interface=Interface, name=u'', context=None):
     adapter = queryMultiAdapter(objects, interface, name, context=context)
     if adapter is None:
         raise ComponentLookupError(objects, interface, name)
     return adapter
 
-def queryMultiAdapter(objects, interface=Interface, name=_BLANK, default=None,
+def queryMultiAdapter(objects, interface=Interface, name=u'', default=None,
                       context=None):
     try:
         sitemanager = getSiteManager(context)
@@ -195,7 +194,7 @@ def getNextUtility(context, interface, name=''):
     """
     util = queryNextUtility(context, interface, name, _marker)
     if util is _marker:
-        raise zope.component.interfaces.ComponentLookupError(
+        raise ComponentLookupError(
             "No more utilities for %s, '%s' have been found." % (
                 interface, name))
     return util

--- a/src/zope/component/_compat.py
+++ b/src/zope/component/_compat.py
@@ -32,5 +32,3 @@ else: #pragma NO COVER
 
     PYTHON3 = True
     PYTHON2 = False
-
-_BLANK = u''

--- a/src/zope/component/_declaration.py
+++ b/src/zope/component/_declaration.py
@@ -15,7 +15,7 @@
 """
 import sys
 
-from zope.component._compat import CLASS_TYPES, _BLANK
+from zope.component._compat import CLASS_TYPES
 
 class adapter(object):
 
@@ -47,7 +47,7 @@ def adaptedBy(ob):
     return getattr(ob, '__component_adapts__', None)
 
 def getName(ob):
-    return getattr(ob, '__component_name__', _BLANK)
+    return getattr(ob, '__component_name__', u'')
 
 class _adapts_descr(object):
     def __init__(self, interfaces):

--- a/src/zope/component/event.py
+++ b/src/zope/component/event.py
@@ -18,7 +18,7 @@ Based on subscription adapters / handlers.
 
 from zope.event import subscribers as event_subscribers
 
-from zope.component.interfaces import IObjectEvent
+from zope.interface.interfaces import IObjectEvent
 from zope.component._api import subscribers as component_subscribers
 from zope.component._declaration import adapter
 

--- a/src/zope/component/globalregistry.py
+++ b/src/zope/component/globalregistry.py
@@ -17,8 +17,8 @@ from zope.interface import implementer
 from zope.interface.adapter import AdapterRegistry
 from zope.interface.registry import Components
 
-from zope.component.interfaces import IComponentLookup
-from zope.component._compat import _BLANK
+from zope.interface.interfaces import IComponentLookup
+
 
 def GAR(components, registryName):
     return getattr(components, registryName)
@@ -66,10 +66,10 @@ def getGlobalSiteManager():
 # We eventually want to deprecate these in favor of using the global
 # component registry directly.
 
-def provideUtility(component, provides=None, name=_BLANK):
+def provideUtility(component, provides=None, name=u''):
     base.registerUtility(component, provides, name, event=False)
 
-def provideAdapter(factory, adapts=None, provides=None, name=_BLANK):
+def provideAdapter(factory, adapts=None, provides=None, name=u''):
     base.registerAdapter(factory, adapts, provides, name, event=False)
 
 def provideSubscriptionAdapter(factory, adapts=None, provides=None):

--- a/src/zope/component/hookable.py
+++ b/src/zope/component/hookable.py
@@ -14,5 +14,5 @@
 """
 This module is deprecated. Prefer to use zope.hookable.hookable.
 """
-from zope.hookable import hookable
-hookable = hookable # BBB
+import zope.deprecation
+zope.deprecation.moved("zope.hookable", "4.5")

--- a/src/zope/component/hooks.py
+++ b/src/zope/component/hooks.py
@@ -25,8 +25,8 @@ except ImportError: #pragma NO COVER
         return x
 
 from zope.component.globalregistry import getGlobalSiteManager
-from zope.component.interfaces import ComponentLookupError
-from zope.component.interfaces import IComponentLookup
+from zope.interface.interfaces import ComponentLookupError
+from zope.interface.interfaces import IComponentLookup
 
 
 class read_property(object):

--- a/src/zope/component/interface.py
+++ b/src/zope/component/interface.py
@@ -17,7 +17,7 @@ from zope.interface import alsoProvides
 from zope.interface.interfaces import IInterface
 
 from zope.component.globalregistry import getGlobalSiteManager
-from zope.component.interfaces import ComponentLookupError
+from zope.interface.interfaces import ComponentLookupError
 from zope.component._api import queryUtility
 from zope.component._compat import CLASS_TYPES
 

--- a/src/zope/component/interfaces.py
+++ b/src/zope/component/interfaces.py
@@ -18,27 +18,30 @@ from zope.interface import Interface
 
 
 # BBB 2011-09-09, import interfaces from zope.interface
-from zope.interface.interfaces import ComponentLookupError
-from zope.interface.interfaces import Invalid
-from zope.interface.interfaces import IObjectEvent
-from zope.interface.interfaces import ObjectEvent
-from zope.interface.interfaces import IComponentLookup
-from zope.interface.interfaces import IRegistration
-from zope.interface.interfaces import IUtilityRegistration
-from zope.interface.interfaces import _IBaseAdapterRegistration
-from zope.interface.interfaces import IAdapterRegistration
-from zope.interface.interfaces import ISubscriptionAdapterRegistration
-from zope.interface.interfaces import IHandlerRegistration
-from zope.interface.interfaces import IRegistrationEvent
-from zope.interface.interfaces import RegistrationEvent
-from zope.interface.interfaces import IRegistered
-from zope.interface.interfaces import Registered
-from zope.interface.interfaces import IUnregistered
-from zope.interface.interfaces import Unregistered
-from zope.interface.interfaces import IComponentRegistry
-from zope.interface.interfaces import IComponents
-
-from zope.component._compat import _BLANK
+import zope.deferredimport
+zope.deferredimport.deprecatedFrom(
+    "Import from zope.interface.interfaces",
+    "zope.interface.interfaces",
+    'ComponentLookupError',
+    'Invalid',
+    'IObjectEvent',
+    'ObjectEvent',
+    'IComponentLookup',
+    'IRegistration',
+    'IUtilityRegistration',
+    '_IBaseAdapterRegistration',
+    'IAdapterRegistration',
+    'ISubscriptionAdapterRegistration',
+    'IHandlerRegistration',
+    'IRegistrationEvent',
+    'RegistrationEvent',
+    'IRegistered',
+    'Registered',
+    'IUnregistered',
+    'Unregistered',
+    'IComponentRegistry',
+    'IComponents',
+)
 
 
 class IComponentArchitecture(Interface):
@@ -115,7 +118,7 @@ class IComponentArchitecture(Interface):
     # Adapter API
 
     def getAdapter(object,
-                   interface=Interface, name=_BLANK,
+                   interface=Interface, name=u'',
                    context=None):
         """Get a named adapter to an interface for an object
 
@@ -170,7 +173,7 @@ class IComponentArchitecture(Interface):
         named adapter methods with an empty string for a name.
         """
 
-    def queryAdapter(object, interface=Interface, name=_BLANK,
+    def queryAdapter(object, interface=Interface, name=u'',
                      default=None, context=None):
         """Look for a named adapter to an interface for an object
 
@@ -207,7 +210,7 @@ class IComponentArchitecture(Interface):
         """
 
     def queryMultiAdapter(objects,
-                          interface=Interface, name=_BLANK,
+                          interface=Interface, name=u'',
                           default=None,
                           context=None):
         """Look for a multi-adapter to an interface for objects
@@ -319,7 +322,7 @@ class IComponentRegistrationConvenience(Interface):
     activity.
     """
 
-    def provideUtility(component, provides=None, name=_BLANK):
+    def provideUtility(component, provides=None, name=u''):
         """Register a utility globally
 
         A utility is registered to provide an interface with a
@@ -335,7 +338,7 @@ class IComponentRegistrationConvenience(Interface):
 
         """
 
-    def provideAdapter(factory, adapts=None, provides=None, name=_BLANK):
+    def provideAdapter(factory, adapts=None, provides=None, name=u''):
         """Register an adapter globally
 
         An adapter is registered to provide an interface with a name

--- a/src/zope/component/interfaces.py
+++ b/src/zope/component/interfaces.py
@@ -15,9 +15,9 @@
 """
 from zope.interface import Attribute
 from zope.interface import Interface
-from zope.interface import implements
 
-# BBB 2011-09-09, import interfaces from zope.interface 
+
+# BBB 2011-09-09, import interfaces from zope.interface
 from zope.interface.interfaces import ComponentLookupError
 from zope.interface.interfaces import Invalid
 from zope.interface.interfaces import IObjectEvent
@@ -85,15 +85,15 @@ class IComponentArchitecture(Interface):
 
     def queryNextUtility(context, interface, name='', default=None):
         """Query for the next available utility.
-    
+
         Find the next available utility providing `interface` and having the
         specified name. If no utility was found, return the specified `default`
         value.
         """
-    
+
     def getNextUtility(context, interface, name=''):
         """Get the next available utility.
-    
+
         If no utility was found, a `ComponentLookupError` is raised.
         """
 
@@ -432,4 +432,3 @@ class IFactory(Interface):
         created by this factory will implement. If the callable's Implements
         instance cannot be created, an empty Implements instance is returned.
         """
-

--- a/src/zope/component/registry.py
+++ b/src/zope/component/registry.py
@@ -13,24 +13,31 @@
 ##############################################################################
 """Basic components support
 """
-# BBB, import component-related from zope.interface
-from zope.interface.registry import Components
-from zope.interface.registry import _getUtilityProvided
-from zope.interface.registry import _getAdapterProvided
-from zope.interface.registry import _getAdapterRequired
-from zope.interface.registry import UtilityRegistration
-from zope.interface.registry import AdapterRegistration
-from zope.interface.registry import SubscriptionRegistration
-from zope.interface.registry import HandlerRegistration
 
 from zope.component._api import handle
 from zope.component._declaration import adapter
 
-from zope.component.interfaces import IAdapterRegistration
-from zope.component.interfaces import IHandlerRegistration
-from zope.component.interfaces import IRegistrationEvent
-from zope.component.interfaces import ISubscriptionAdapterRegistration
-from zope.component.interfaces import IUtilityRegistration
+from zope.interface.interfaces import IAdapterRegistration
+from zope.interface.interfaces import IHandlerRegistration
+from zope.interface.interfaces import IRegistrationEvent
+from zope.interface.interfaces import ISubscriptionAdapterRegistration
+from zope.interface.interfaces import IUtilityRegistration
+
+# BBB, import component-related from zope.interface
+import zope.deferredimport
+zope.deferredimport.deprecatedFrom(
+    "Import from zope.interface.registry",
+    "zope.interface.registry",
+    'Components',
+    '_getUtilityProvided',
+    '_getAdapterProvided',
+    '_getAdapterRequired',
+    'UtilityRegistration',
+    'AdapterRegistration',
+    'SubscriptionRegistration',
+    'HandlerRegistration',
+)
+
 
 @adapter(IUtilityRegistration, IRegistrationEvent)
 def dispatchUtilityRegistrationEvent(registration, event):

--- a/src/zope/component/tests/examples.py
+++ b/src/zope/component/tests/examples.py
@@ -127,7 +127,7 @@ class ConformsToIComponentLookup(object):
 
     def __conform__(self, interface):
         """This method is specified by the adapter PEP to do the adaptation."""
-        from zope.component.interfaces import IComponentLookup
+        from zope.interface.interfaces import IComponentLookup
         if interface is IComponentLookup:
             return self.sitemanager
 

--- a/src/zope/component/tests/test__api.py
+++ b/src/zope/component/tests/test__api.py
@@ -26,7 +26,7 @@ class Test_getSiteManager(unittest.TestCase):
         return getSiteManager(*args, **kw)
 
     def test_sm_is_IComponentLookup(self):
-        from zope.component.interfaces import IComponentLookup
+        from zope.interface.interfaces import IComponentLookup
         sm = self._callFUT()
         self.assertTrue(IComponentLookup.providedBy(sm))
 
@@ -46,13 +46,13 @@ class Test_getSiteManager(unittest.TestCase):
         self.assertTrue(self._callFUT(context) is sitemanager)
 
     def test_getSiteManager_w_invalid_context_no_adapter(self):
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         self.assertRaises(ComponentLookupError, self._callFUT, object())
 
     def test_getSiteManager_w_invalid_context_w_adapter(self):
         from zope.interface import Interface
         from zope.component.globalregistry import getGlobalSiteManager
-        from zope.component.interfaces import IComponentLookup
+        from zope.interface.interfaces import IComponentLookup
         gsm = getGlobalSiteManager()
         sm = object()
         def _adapt(x):
@@ -71,7 +71,7 @@ class Test_getAdapterInContext(unittest.TestCase):
 
     def test_miss(self):
         from zope.interface import Interface
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         class IFoo(Interface):
             pass
         self.assertRaises(ComponentLookupError,
@@ -185,7 +185,7 @@ class Test_getAdapter(unittest.TestCase):
 
     def test_anonymous_nonesuch(self):
         from zope.interface import Interface
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         class IFoo(Interface):
             pass
         self.assertRaises(ComponentLookupError,
@@ -193,7 +193,7 @@ class Test_getAdapter(unittest.TestCase):
 
     def test_named_nonesuch(self):
         from zope.interface import Interface
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         class IFoo(Interface):
             pass
         self.assertRaises(ComponentLookupError,
@@ -364,7 +364,7 @@ class Test_getMultiAdapter(unittest.TestCase):
 
     def test_anonymous_nonesuch(self):
         from zope.interface import Interface
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         class IFoo(Interface):
             pass
         self.assertRaises(ComponentLookupError,
@@ -372,7 +372,7 @@ class Test_getMultiAdapter(unittest.TestCase):
 
     def test_named_nonesuch(self):
         from zope.interface import Interface
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         class IFoo(Interface):
             pass
         self.assertRaises(ComponentLookupError,
@@ -586,7 +586,7 @@ class Test_queryMultiAdapter(unittest.TestCase):
     def test_wo_sitemanager(self):
         from zope.interface import Interface
         from zope.interface import implementer
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         class IFoo(Interface):
             pass
         class IBar(Interface):
@@ -645,7 +645,7 @@ class Test_getAdapters(unittest.TestCase):
     def test_wo_sitemanager(self):
         from zope.interface import Interface
         from zope.interface import implementer
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         class IFoo(Interface):
             pass
         class IBar(Interface):
@@ -704,7 +704,7 @@ class Test_subscribers(unittest.TestCase):
 
     def test_wo_sitemanager(self):
         from zope.interface import Interface
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         class IFoo(Interface):
             pass
         class Context(object):
@@ -761,14 +761,14 @@ class Test_getUtility(unittest.TestCase):
 
     def test_anonymous_nonesuch(self):
         from zope.interface import Interface
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         class IFoo(Interface):
             pass
         self.assertRaises(ComponentLookupError, self._callFUT, IFoo)
 
     def test_named_nonesuch(self):
         from zope.interface import Interface
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         class IFoo(Interface):
             pass
         self.assertRaises(ComponentLookupError,
@@ -964,7 +964,7 @@ class Test_getNextUtility(unittest.TestCase):
 
     def test_nested(self):
         from zope.component import getGlobalSiteManager
-        from zope.component.interfaces import IComponentLookup
+        from zope.interface.interfaces import IComponentLookup
         from zope.interface.registry import Components
         gsm = getGlobalSiteManager()
         gutil = _makeMyUtility('global', gsm)
@@ -1019,7 +1019,7 @@ class Test_queryNextUtility(unittest.TestCase):
 
     def test_wo_sitemanager(self):
         from zope.interface import Interface
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         class IFoo(Interface):
             pass
         class Context(object):
@@ -1037,7 +1037,7 @@ class Test_createObject(unittest.TestCase):
         return createObject(*args, **kw)
 
     def test_miss(self):
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         self.assertRaises(ComponentLookupError, self._callFUT, 'nonesuch')
 
     def test_hit(self):
@@ -1069,7 +1069,7 @@ class Test_getFactoryInterfaces(unittest.TestCase):
         return getFactoryInterfaces(*args, **kw)
 
     def test_miss(self):
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         self.assertRaises(ComponentLookupError, self._callFUT, 'nonesuch')
 
     def test_hit(self):

--- a/src/zope/component/tests/test_event.py
+++ b/src/zope/component/tests/test_event.py
@@ -38,7 +38,7 @@ class Test_objectEventNotify(unittest.TestCase):
         from zope.interface import Interface
         from zope.interface import implementer
         from zope.component.globalregistry import getGlobalSiteManager
-        from zope.component.interfaces import IObjectEvent
+        from zope.interface.interfaces import IObjectEvent
         from zope.component.event import objectEventNotify
         _adapted = []
         def _adapter(context, event):
@@ -63,4 +63,3 @@ def test_suite():
         unittest.makeSuite(Test_dispatch),
         unittest.makeSuite(Test_objectEventNotify),
     ))
-

--- a/src/zope/component/tests/test_globalregistry.py
+++ b/src/zope/component/tests/test_globalregistry.py
@@ -25,7 +25,7 @@ class Test_getGlobalSiteManager(unittest.TestCase):
 
     def test_gsm_is_IComponentLookup(self):
         from zope.component.globalregistry import base
-        from zope.component.interfaces import IComponentLookup
+        from zope.interface.interfaces import IComponentLookup
         gsm = self._callFUT()
         self.assertTrue(gsm is base)
         self.assertTrue(IComponentLookup.providedBy(gsm))

--- a/src/zope/component/tests/test_globalregistry.py
+++ b/src/zope/component/tests/test_globalregistry.py
@@ -102,7 +102,7 @@ class Test_provideAdapter(unittest.TestCase):
         from zope.interface import Interface
         from zope.interface import implementer
         from zope.component.globalregistry import getGlobalSiteManager
-        from zope.component._api import adapter
+        from zope.component._declaration import adapter
         class IFoo(Interface):
             pass
         class IBar(Interface):
@@ -156,7 +156,7 @@ class Test_provideSubscriptionAdapter(unittest.TestCase):
         from zope.interface import Interface
         from zope.interface import implementer
         from zope.component.globalregistry import getGlobalSiteManager
-        from zope.component._api import adapter
+        from zope.component._declaration import adapter
         class IFoo(Interface):
             pass
         class IBar(Interface):
@@ -213,7 +213,7 @@ class Test_provideHandler(unittest.TestCase):
         from zope.interface import implementer
         from zope.interface import providedBy
         from zope.component.globalregistry import getGlobalSiteManager
-        from zope.component._api import adapter
+        from zope.component._declaration import adapter
         class IFoo(Interface):
             pass
         @implementer(IFoo)

--- a/src/zope/component/tests/test_hooks.py
+++ b/src/zope/component/tests/test_hooks.py
@@ -196,7 +196,7 @@ class Test_getSiteManager(unittest.TestCase):
         from zope.interface import Interface
         from zope.component import hooks
         from zope.component.globalregistry import getGlobalSiteManager
-        from zope.component.interfaces import IComponentLookup
+        from zope.interface.interfaces import IComponentLookup
         class _Lookup(object):
             def __init__(self, context):
                 self.context = context
@@ -243,7 +243,7 @@ class Test_adapter_hook(unittest.TestCase):
         from zope.interface import Interface
         from zope.component import hooks
         from zope.component.globalregistry import getGlobalSiteManager
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         class IFoo(Interface):
             pass
         gsm = getGlobalSiteManager()

--- a/src/zope/component/tests/test_interface.py
+++ b/src/zope/component/tests/test_interface.py
@@ -83,7 +83,7 @@ class Test_getInterface(unittest.TestCase):
         return getInterface(*args, **kw)
 
     def test_miss(self):
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         self.assertRaises(ComponentLookupError,
                           self._callFUT, object(), 'nonesuch')
 
@@ -298,7 +298,7 @@ class Test_getInterfaceAllDocs(unittest.TestCase):
             def baz(self):
                 """BAZ"""
         self.assertEqual(self._callFUT(Foo),
-                         'zope.component.tests.test_interface.foo\n' + 
+                         'zope.component.tests.test_interface.foo\n' +
                          'docstring')
 
     def test_w_interface_no_members(self):
@@ -306,7 +306,7 @@ class Test_getInterfaceAllDocs(unittest.TestCase):
         class IFoo(Interface):
             """DOCSTRING"""
         self.assertEqual(self._callFUT(IFoo),
-                         'zope.component.tests.test_interface.ifoo\n' + 
+                         'zope.component.tests.test_interface.ifoo\n' +
                          'docstring')
 
     def test_w_interface_w_members(self):
@@ -319,7 +319,7 @@ class Test_getInterfaceAllDocs(unittest.TestCase):
                 """BAZ"""
         self.assertEqual(self._callFUT(IFoo),
                          'zope.component.tests.test_interface.ifoo\n' +
-                         'docstring\n' + 
+                         'docstring\n' +
                          'do bar\n' +
                          'baz')
 
@@ -336,7 +336,7 @@ class Test_nameToInterface(unittest.TestCase):
         self.assertTrue(self._callFUT(object(), 'None') is None)
 
     def test_miss(self):
-        from zope.component.interfaces import ComponentLookupError
+        from zope.interface.interfaces import ComponentLookupError
         self.assertRaises(ComponentLookupError,
                           self._callFUT, object(), 'nonesuch')
 
@@ -394,4 +394,3 @@ def test_suite():
         unittest.makeSuite(Test_nameToInterface),
         unittest.makeSuite(Test_interfaceToName),
     ))
-

--- a/src/zope/component/tests/test_interfaces.py
+++ b/src/zope/component/tests/test_interfaces.py
@@ -1,0 +1,53 @@
+##############################################################################
+#
+# Copyright (c) 2017 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""
+Tests for zope.component.interfaces
+"""
+
+import unittest
+
+class TestBackwardsCompat(unittest.TestCase):
+
+    def test_interface_warnings(self):
+        from zope.component import interfaces
+        import warnings
+        for name in (
+                'ComponentLookupError',
+                'Invalid',
+                'IObjectEvent',
+                'ObjectEvent',
+                'IComponentLookup',
+                'IRegistration',
+                'IUtilityRegistration',
+                '_IBaseAdapterRegistration',
+                'IAdapterRegistration',
+                'ISubscriptionAdapterRegistration',
+                'IHandlerRegistration',
+                'IRegistrationEvent',
+                'RegistrationEvent',
+                'IRegistered',
+                'Registered',
+                'IUnregistered',
+                'Unregistered',
+                'IComponentRegistry',
+                'IComponents',
+        ):
+            with warnings.catch_warnings(record=True) as log:
+                warnings.simplefilter("always")
+                getattr(interfaces, name)
+
+                self.assertEqual(1, len(log), name)
+                message = str(log[0].message)
+                self.assertIn(name, message)
+                self.assertIn("Import from zope.interface.interfaces", message)

--- a/src/zope/component/tests/test_registry.py
+++ b/src/zope/component/tests/test_registry.py
@@ -105,6 +105,31 @@ class Test_dispatchHandlerRegistrationEvent(unittest.TestCase):
         self.assertEqual(_handled, [(_registration.handler, _EVENT)])
 
 
+class TestBackwardsCompat(unittest.TestCase):
+
+    def test_interface_warnings(self):
+        from zope.component import registry
+        import warnings
+        for name in (
+                'Components',
+                '_getUtilityProvided',
+                '_getAdapterProvided',
+                '_getAdapterRequired',
+                'UtilityRegistration',
+                'AdapterRegistration',
+                'SubscriptionRegistration',
+                'HandlerRegistration',
+        ):
+            with warnings.catch_warnings(record=True) as log:
+                warnings.simplefilter("always")
+                getattr(registry, name)
+
+                self.assertEqual(1, len(log), name)
+                message = str(log[0].message)
+                self.assertIn(name, message)
+                self.assertIn("Import from zope.interface.registry", message)
+
+
 class _Monkey(object):
     # context-manager for replacing module names in the scope of a test.
     def __init__(self, module, **kw):

--- a/src/zope/component/tests/test_zcml.py
+++ b/src/zope/component/tests/test_zcml.py
@@ -28,7 +28,6 @@ class Test_handler(unittest.TestCase):
         from zope.interface.registry import Components
         from zope.component import getSiteManager
         from zope.component.testfiles.components import comp, IApp
-        from zope.component._compat import _BLANK
 
         registry = Components()
         def dummy(context=None):
@@ -36,7 +35,7 @@ class Test_handler(unittest.TestCase):
         getSiteManager.sethook(dummy)
 
         try:
-            self._callFUT('registerUtility', comp, IApp, _BLANK)
+            self._callFUT('registerUtility', comp, IApp, u'')
             self.assertTrue(registry.getUtility(IApp) is comp)
         finally:
             getSiteManager.reset()

--- a/src/zope/component/zcml.py
+++ b/src/zope/component/zcml.py
@@ -28,7 +28,6 @@ from zope.schema import TextLine
 from zope.component._api import getSiteManager
 from zope.component._declaration import adaptedBy, getName
 from zope.component.interface import provideInterface
-from zope.component._compat import _BLANK
 
 try:
     from zope.security.zcml import Permission
@@ -327,14 +326,14 @@ def subscriber(_context, for_=None, factory=None, handler=None, provides=None,
             discriminator = None,
             callable = _handler,
             args = ('registerHandler',
-                    handler, for_, _BLANK, _context.info),
+                    handler, for_, u'', _context.info),
             )
     else:
         _context.action(
             discriminator = None,
             callable = _handler,
             args = ('registerSubscriptionAdapter',
-                    factory, for_, provides, _BLANK, _context.info),
+                    factory, for_, provides, u'', _context.info),
             )
 
     if provides is not None:
@@ -492,7 +491,7 @@ class IBasicResourceInformation(Interface):
         title=_("The name of the resource."),
         description=_("The name shows up in URLs/paths. For example 'foo'."),
         required=True,
-        default=_BLANK,
+        default=u'',
         )
 
     provides = GlobalInterface(
@@ -594,7 +593,7 @@ def view(_context, factory, type, name, for_,
                     args = ('', iface)
                     )
 
-    
+
 class IResourceDirective(IBasicComponentInformation,
                          IBasicResourceInformation):
     """Register a resource"""


### PR DESCRIPTION
In interfaces.py and registry.py and hookable.py

See https://github.com/zopefoundation/zope.component/pull/36#discussion_r149631796

Do this using zope.deferredimport and zope.deprecation, two new dependencies. This introduces a transitive dependency on zope.proxy, but that was already part of the 'security' extra. zope.proxy runs on pypy but it doesn't yet support making the C extension optional (zopefoundation/zope.proxy#26)

Also drop the use of _compat._BLANK everywhere and just use the literal.

Also remove unused but not BBB exported imports from _api.py in its own commit.