### PR TITLE
Fix tests on Python 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 4.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix tests on Python 2 following changes in ZODB 5.5.0.
 
 
 4.5 (2018-10-10)

--- a/docs/api/persistent.rst
+++ b/docs/api/persistent.rst
@@ -16,8 +16,8 @@ managers and database connections to work with.
 
 .. doctest::
 
-    >>> import ZODB.tests.util
-    >>> db = ZODB.tests.util.DB()
+    >>> import ZODB.MappingStorage
+    >>> db = ZODB.MappingStorage.DB()
     >>> import transaction
     >>> t1 = transaction.TransactionManager()
     >>> c1 = db.open(transaction_manager=t1)
@@ -126,8 +126,8 @@ Subscription to Events in Persistent Registries
 
 .. doctest::
 
-    >>> import ZODB.tests.util
-    >>> db = ZODB.tests.util.DB()
+    >>> import ZODB.MappingStorage
+    >>> db = ZODB.MappingStorage.DB()
     >>> import transaction
     >>> t1 = transaction.TransactionManager()
     >>> c1 = db.open(transaction_manager=t1)
@@ -183,8 +183,8 @@ We want to make sure that we see updates corrextly.
     >>> len(base._v_subregistries)
     0
 
-    >>> import ZODB.tests.util
-    >>> db = ZODB.tests.util.DB()
+    >>> import ZODB.MappingStorage
+    >>> db = ZODB.MappingStorage.DB()
     >>> tm1 = transaction.TransactionManager()
     >>> c1 = db.open(transaction_manager=tm1)
     >>> from zope.component.persistentregistry import PersistentAdapterRegistry


### PR DESCRIPTION
ZODB 5.5.0 added an "import mock" to ZODB.tests.util (or "from unittest
import mock" on Python 3, which is in the standard library).  ZODB[test]
included the new dependency, but zope.component wasn't using that for
tests.

However, ZODB.tests.util.DB was just an import of
ZODB.MappingStorage.DB, so we can just as easily use the latter and
avoid the extra dependency.