### PR TITLE
Make PersistentAdapterRegistry use PersistentMapping/PersistentList 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,24 @@
   before. See `issue 9
   <https://github.com/zopefoundation/zope.component/issues/9>`_.
 
+- Make ``PersistentAdapterRegistry`` use persistent objects
+  (``PersistentMapping`` and ``PersistentList``) for its internal data
+  structures instead of plain dicts and lists. This helps make it
+  scalable to larger registry sizes.
+
+  To take advantage of this, you need zope.interface 5.3 or later
+  (earlier versions continue to work, but do not allow this
+  optimization).
+
+  New registries (and their primary user, ``PersistentComponents`` and
+  zope.site's ``LocalSiteManager``) take full advantage of this
+  automatically. For existing persistent registries to take advantage
+  of this, you must call their ``rebuild()`` method and commit the
+  transaction.
+
+  See `issue 51 <https://github.com/zopefoundation/zope.component/issues/51>`_.
+
+
 4.6.2 (2020-07-03)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,11 +31,9 @@
   structures instead of plain dicts and lists. This helps make it
   scalable to larger registry sizes.
 
-  To take advantage of this, you need zope.interface 5.3 or later
-  (earlier versions continue to work, but do not allow this
-  optimization).
+  This requires zope.interface 5.3.0a1 or later.
 
-  New registries (and their primary user, ``PersistentComponents`` and
+  New registries (and their primary users, ``PersistentComponents`` and
   zope.site's ``LocalSiteManager``) take full advantage of this
   automatically. For existing persistent registries to take advantage
   of this, you must call their ``rebuild()`` method and commit the

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ setup(
         'setuptools',
         'zope.event',
         'zope.hookable >= 4.2.0',
-        'zope.interface >= 4.1.0',
+        'zope.interface >= 5.3.0a1',
     ],
     include_package_data=True,
     zip_safe=False,

--- a/src/zope/component/persistentregistry.py
+++ b/src/zope/component/persistentregistry.py
@@ -22,9 +22,69 @@ from zope.interface.registry import Components
 class PersistentAdapterRegistry(VerifyingAdapterRegistry, Persistent):
     """
     An adapter registry that is also a persistent object.
+
+    .. versionchanged:: 4.7.0
+        Internal data structures are now composed of
+        :class:`persistent.mapping.PersistentMapping` and
+        :class:`persistent.list.PersistentList`. This helps scale to
+        larger registries.
+
+        Previously they were :class:`dict`, :class:`list` and
+        :class:`tuple`, meaning that as soon as this object was
+        unpickled, the entire registry tree had to be unpickled, and
+        when a change was made (an object registered or unregisterd),
+        the entire registry had to be pickled. Now, only the parts
+        that are in use are loaded, and only the parts that are
+        modified are stored.
+
+        The above applies without reservation to newly created
+        instances. For existing persistent instances, however, the
+        data will continue to be in dicts and tuples, with some few
+        exceptions for newly added or changed data.
+
+        To fix this, call :meth:`rebuild` and commit the transaction.
+        This will rewrite the internal data structures to use the new
+        types.
     """
+
+    # The persistent types we use, replacing the basic types inherited
+    # from ``BaseAdapterRegistry``.
+    _sequenceType = PersistentList
+    _leafSequenceType = PersistentList
+    _mappingType = PersistentMapping
+    _providedType = PersistentMapping
+
+    # The methods needed to manipulate the leaves of the subscriber
+    # tree. When we're manipulating unmigrated data, it's safe to
+    # migrate it, but not otherwise (we don't want to write in an
+    # otherwise read-only transaction).
+    def _addValueToLeaf(self, existing_leaf_sequence, new_item):
+        if not existing_leaf_sequence:
+            existing_leaf_sequence = self._leafSequenceType()
+        elif isinstance(existing_leaf_sequence, tuple):
+            # Converting from old state.
+            existing_leaf_sequence = self._leafSequenceType(existing_leaf_sequence)
+        existing_leaf_sequence.append(new_item)
+        return existing_leaf_sequence
+
+    def _removeValueFromLeaf(self, existing_leaf_sequence, to_remove):
+        without_removed = VerifyingAdapterRegistry._removeValueFromLeaf(
+            self,
+            existing_leaf_sequence,
+            to_remove)
+        existing_leaf_sequence[:] = without_removed
+        return existing_leaf_sequence
+
     def changed(self, originally_changed):
         if originally_changed is self:
+            # XXX: This is almost certainly redundant, even if we
+            # have old data consisting of plain dict/list/tuple. That's
+            # because the super class will now increment the ``_generation``
+            # attribute to keep caches in sync. For this same reason,
+            # it's not worth trying to "optimize" for the case that we're a
+            # new or rebuilt object containing only Persistent sub-objects:
+            # the changed() mechanism will still result in mutating this
+            # object via ``_generation``.
             self._p_changed = True
         super(PersistentAdapterRegistry, self).changed(originally_changed)
 


### PR DESCRIPTION
Fixes #51. 

This won't actually run on CI until zope.interface 5.3 is released, but can be tested locally, so I'm opening as a draft for comments.

The first commit gets basic GHA up and running, pending a better solution to #52. It could be moved to a separate PR.