### PR TITLE
Standardize the README.rst header level and location.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+================
+ zope.component
+================
+
 .. image:: https://github.com/zopefoundation/zope.component/actions/workflows/tests.yml/badge.svg
         :target: https://github.com/zopefoundation/zope.component/actions/workflows/tests.yml
         :alt: Unit test status
@@ -17,9 +21,6 @@
 .. image:: https://readthedocs.org/projects/zopecomponent/badge/?version=latest
         :target: http://zopecomponent.readthedocs.org/en/latest/
         :alt: Documentation Status
-
-zope.component
-==============
 
 .. note::
 


### PR DESCRIPTION
Match, e.g,. zope.interface, persistent, ZODB, etc.

It now renders better, since the header level is consistent with CHANGES.rst which is concatenated to it.