### PR TITLE
Fix the subscriber directive when a factory is given that implements an interface and no provides= attribute is specified.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@
 
 - Add support for Python 3.9
 
+- Fix the ``<subscriber>`` ZCML directive to allow a missing
+  ``provides=`` attribute when a ``factory=`` is given and the Python
+  object has been decorated with ``@implementer`` and implements a
+  single interface. This has been documented, but hasn't worked
+  before. See `issue 9
+  <https://github.com/zopefoundation/zope.component/issues/9>`_.
 
 4.6.2 (2020-07-03)
 ==================

--- a/docs/zcml.rst
+++ b/docs/zcml.rst
@@ -690,13 +690,12 @@ subscriber should be registered for:
    >>> clearZCML()
    >>> runSnippet('''
    ...   <subscriber
-   ...       provides="zope.component.testfiles.adapter.IS"
    ...       factory="zope.component.testfiles.adapter.A3"
    ...       />''')
 
    >>> content = Content()
    >>> a2 = A2()
-   >>> subscribers = zope.component.subscribers((content, a1, a2), IS)
+   >>> subscribers = zope.component.subscribers((content, a1, a2), I3)
 
    >>> a3 = subscribers[0]
    >>> a3.__class__ is A3

--- a/src/zope/component/tests/test_zcml.py
+++ b/src/zope/component/tests/test_zcml.py
@@ -598,6 +598,29 @@ class Test_subscriber(unittest.TestCase):
         self.assertEqual(action['discriminator'], None)
         self.assertEqual(action['args'], ('', Interface))
 
+    def test_no_for__no_provides_subscriber_adapts_subscriber_implements(self):
+        from zope.interface import Interface
+        from zope.interface import implementer
+        from zope.component._declaration import adapter
+        from zope.component.zcml import handler
+        class IFoo(Interface):
+            pass
+        @adapter(Interface)
+        @implementer(IFoo)
+        class _Factory(object):
+            def __init__(self, context):
+                self.context = context
+        _cfg_ctx = _makeConfigContext()
+        self._callFUT(_cfg_ctx, factory=_Factory)
+        self.assertEqual(len(_cfg_ctx._actions), 3)
+        self.assertEqual(_cfg_ctx._actions[0][0], ())
+        # Register the subscriber
+        action = _cfg_ctx._actions[0][1]
+        self.assertEqual(action['callable'], handler)
+        self.assertIsNone(action['discriminator'])
+        self.assertEqual(action['args'],
+                         ('registerSubscriptionAdapter', _Factory, (Interface,), IFoo,
+                          '', 'TESTING'))
 
 class Test_utility(unittest.TestCase):
 

--- a/src/zope/component/zcml.py
+++ b/src/zope/component/zcml.py
@@ -304,6 +304,10 @@ def subscriber(_context, for_=None, factory=None, handler=None, provides=None,
         if handler is not None:
             raise TypeError("Cannot use handler with factory")
         if provides is None:
+            p = list(implementedBy(factory))
+            if len(p) == 1:
+                provides = p[0]
+        if provides is None:
             raise TypeError(
                 "You must specify a provided interface when registering "
                 "a factory")


### PR DESCRIPTION
Fixes #9

This is a loosening of the existing behaviour, so there shouldn't be any compatibility issues.