### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changes
 =========
 
-6.2 (unreleased)
+7.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 7.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 6.1 (2025-09-09)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@
 
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -44,7 +43,7 @@ ZCML_REQUIRES = [
 
 MIN_TESTS_REQUIRE = (HOOK_REQUIRES + ZCML_REQUIRES + [
     'zope.testing',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
 ])
 
 TESTS_REQUIRE = (MIN_TESTS_REQUIRE + PERSISTENTREGISTRY_REQUIRES +
@@ -72,8 +71,6 @@ setup(
     author_email='zope-dev@zope.dev',
     long_description=(read('README.rst') + '\n' + read('CHANGES.rst')),
     keywords="interface component coupling loose utility adapter",
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
@@ -92,9 +89,6 @@ setup(
         "Framework :: Zope :: 3",
         "Framework :: Zope :: 5",
         "Topic :: Software Development :: Libraries :: Python Modules",
-    ],
-    namespace_packages=[
-        'zope',
     ],
     python_requires='>=3.9',
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def read(*rnames):
 
 setup(
     name='zope.component',
-    version='6.2.dev0',
+    version='7.0.dev0',
     url='https://github.com/zopefoundation/zope.component',
     project_urls={
         'Documentation': 'https://zopecomponent.readthedocs.io/',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
